### PR TITLE
Add New-PlexSmartCollection cmdlet

### DIFF
--- a/Documentation/New-PlexSmartCollection.md
+++ b/Documentation/New-PlexSmartCollection.md
@@ -1,0 +1,223 @@
+---
+external help file: PSPlex-help.xml
+Module Name: PSPlex
+online version:
+schema: 2.0.0
+---
+
+# New-PlexSmartCollection
+
+## SYNOPSIS
+Creates a new smart collection.
+
+## SYNTAX
+
+```
+New-PlexSmartCollection [-Name] <String> [-LibraryID] <String> [-Filter] <String> [[-MatchType] <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a new smart collection.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+New-PlexSmartCollection -Name "Star Trek" -LibraryID 1 -Filter "Title Contains Star Trek"
+```
+
+### EXAMPLE 2
+```
+New-PlexSmartCollection -Name "80's" -LibraryID 1 -Filter "Decade Is 1980"
+```
+
+### EXAMPLE 3
+```
+New-PlexSmartCollection -Name "Old Favorites" -LibraryID 1 -Filter "Plays IsGreaterThan 2; LastPlayed IsNotInTheLast 1y"
+```
+
+### EXAMPLE 4
+```
+New-PlexSmartCollection -Name "Trek Wars" -LibraryID 1 -MatchType MatchAny -Filter "title contains star trek; title contains star wars"
+```
+
+## PARAMETERS
+
+### -Name
+Name of the smart collection.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LibraryID
+ID of the library to create the smart collection in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Filter
+Specifies the query string that retrieves the items in the smart collection.
+The syntax matches the Plex Web GUI as closely as possible.
+Clauses are separated by a semi-colon ( ; ).
+
+Syntax:
+
+\<Atttribute\> \<Operator\> \<Value\>
+\<Atttribute\> \<Operator\> \<Value\>;\<Atttribute\> \<Operator\> \<Value\>
+
+Attributes:
+    - String
+        - Title
+        - Studio
+        - Edition
+    - Numeric
+        - Rating
+        - Year
+        - Decade
+        - Plays
+    - Exact
+        - ContentRating
+        - Genre
+        - Collection
+        - Actor
+        - Country
+        - SubtitleLanguage
+        - AudioLanguage
+        - Label
+    - Boolean
+        - Unmatched
+        - Duplicate
+        - Unplayed
+        - HDR
+        - InProgress
+        - Trash
+    - Semi-Boolean
+        - Resolution
+    - Date
+        - ReleaseDate
+        - DateAdded
+        - LastPlayed
+
+Operators:
+    - String
+        - Contains
+        - DoesNotContain
+        - Is
+        - IsNot
+        - BeginsWith
+        - EndsWith
+    - Numeric
+        - Is
+        - IsNot
+        - IsGreaterThan
+        - IsLessThan
+    - Exact
+        - Is
+        - IsNot
+    - Boolean
+        - IsTrue
+        - IsFalse
+    - Semi-Boolean
+        - Is
+    - Date
+        - IsBefore (Value format: yyyy-mm-dd)
+        - IsAfter (Value format: yyyy-mm-dd)
+        - IsInTheLast
+        - IsNotInTheLast
+
+Examples:
+
+    - "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
+    - "Title BeginsWith Star Trek; Unplayed IsTrue"
+    - "Actor Is Jim Carrey; Genre Is Comedy"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MatchType
+Specifies how filter clauses are matched.
+
+- MatchAll: Matches all clauses.
+- MatchAny: Matches any cluase.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: MatchAll
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Documentation/New-PlexSmartCollection.md
+++ b/Documentation/New-PlexSmartCollection.md
@@ -81,74 +81,73 @@ Clauses are separated by a semi-colon ( ; ).
 
 Syntax:
 
-\<Atttribute\> \<Operator\> \<Value\>
-\<Atttribute\> \<Operator\> \<Value\>;\<Atttribute\> \<Operator\> \<Value\>
+- \<Atttribute\> \<Operator\> \<Value\>
+- \<Atttribute\> \<Operator\> \<Value\>;\<Atttribute\> \<Operator\> \<Value\>
 
-Attributes:
-    - String
-        - Title
-        - Studio
-        - Edition
-    - Numeric
-        - Rating
-        - Year
-        - Decade
-        - Plays
-    - Exact
-        - ContentRating
-        - Genre
-        - Collection
-        - Actor
-        - Country
-        - SubtitleLanguage
-        - AudioLanguage
-        - Label
-    - Boolean
-        - Unmatched
-        - Duplicate
-        - Unplayed
-        - HDR
-        - InProgress
-        - Trash
-    - Semi-Boolean
-        - Resolution
-    - Date
-        - ReleaseDate
-        - DateAdded
-        - LastPlayed
+- Attributes:
+  - String
+    - Title
+    - Studio
+    - Edition
+  - Numeric
+    - Rating
+    - Year
+    - Decade
+    - Plays
+  - Exact
+    - ContentRating
+    - Genre
+    - Collection
+    - Actor
+    - Country
+    - SubtitleLanguage
+    - AudioLanguage
+    - Label
+  - Boolean
+    - Unmatched
+    - Duplicate
+    - Unplayed
+    - HDR
+    - InProgress
+    - Trash
+  - Semi-Boolean
+    - Resolution
+  - Date
+    - ReleaseDate
+    - DateAdded
+    - LastPlayed
 
-Operators:
-    - String
-        - Contains
-        - DoesNotContain
-        - Is
-        - IsNot
-        - BeginsWith
-        - EndsWith
-    - Numeric
-        - Is
-        - IsNot
-        - IsGreaterThan
-        - IsLessThan
-    - Exact
-        - Is
-        - IsNot
-    - Boolean
-        - IsTrue
-        - IsFalse
-    - Semi-Boolean
-        - Is
-    - Date
-        - IsBefore (Value format: yyyy-mm-dd)
-        - IsAfter (Value format: yyyy-mm-dd)
-        - IsInTheLast
-        - IsNotInTheLast
+- Operators:
+  - String
+    - Contains
+    - DoesNotContain
+    - Is
+    - IsNot
+    - BeginsWith
+    - EndsWith
+  - Numeric
+    - Is
+    - IsNot
+    - IsGreaterThan
+    - IsLessThan
+  - Exact
+    - Is
+    - IsNot
+  - Boolean
+    - IsTrue
+    - IsFalse
+  - Semi-Boolean
+    - Is
+  - Date
+    - IsBefore (Value format: yyyy-mm-dd)
+    - IsAfter (Value format: yyyy-mm-dd)
+    - IsInTheLast
+    - IsNotInTheLast
 
-Examples:
-
-    - "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
-    - "Title BeginsWith Star Trek; Unplayed IsTrue"
-    - "Actor Is Jim Carrey; Genre Is Comedy"
+- Examples:
+  - "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
+  - "Title BeginsWith Star Trek; Unplayed IsTrue"
+  - "Actor Is Jim Carrey; Genre Is Comedy"
 
 ```yaml
 Type: String

--- a/Source/PSPlex.psd1
+++ b/Source/PSPlex.psd1
@@ -84,6 +84,7 @@
         'Get-PlexUser'
         'Get-PlexWatchHistory'
         'New-PlexPlaylist'
+        'New-PlexSmartCollection'
         'Remove-PlexCollection'
         'Remove-PlexPlaylist'
         'Remove-PlexLabel'

--- a/Source/Private/Resolve-PlexFilter.ps1
+++ b/Source/Private/Resolve-PlexFilter.ps1
@@ -77,7 +77,7 @@ function Resolve-PlexFilter
 
         # Copied from Plex web GUI and translated into Plex DB attributes.
         $Attributes = @{
-            # NameinGUI        = @{ Class = "ClassName" ; Name = "NameInDB" }
+            # NameinGUI      = @{ Class = "ClassName" ; Name = "NameInDB" }
             Title            = @{ Class = "String" ; Name = "title" }
             Studio           = @{ Class = "String" ; Name = "studio" }
             Edition          = @{ Class = "String" ; Name = "editionTitle" }
@@ -133,6 +133,7 @@ function Resolve-PlexFilter
                 # Translate Exact class into Plex DB key
                 if ($Attribute.Class -eq 'Exact')
                 {
+                    # Import PlexConfigData
                     if (!$script:PlexConfigData)
                     {
                         try
@@ -144,11 +145,12 @@ function Resolve-PlexFilter
                             throw $_
                         }
                     }
-                    $Uri = Get-PlexAPIUri -RestEndpoint "library/sections/$($PSBoundParameters.LibraryID)/$($Attribute.Name)" -ErrorAction Stop
+                    $Uri = Get-PlexAPIUri -RestEndpoint "library/sections/$LibraryID/$($Attribute.Name)" -ErrorAction Stop
                     $Key = ((Invoke-RestMethod -Uri $Uri -Method Get -ErrorAction Stop).MediaContainer.Directory | Where-Object { $_.title -eq $Matches.Value }).key
+                    #TODO implement caching for attribute keys
                     if (-not ($Key -or $IKnowWhatImDoing))
                     {
-                        throw ("Unable to find key for '{0}' in library '{1}'." -f $Matches.Value, $PSBoundParameters.LibraryID)
+                        throw ("Unable to find key for '{0}' in library '{1}'." -f $Matches.Value, $LibraryID)
                     }
 
                     $Matches.Value = @($Matches.Value, $Key)[[bool]$Key] # Null check for key

--- a/Source/Private/Resolve-PlexFilter.ps1
+++ b/Source/Private/Resolve-PlexFilter.ps1
@@ -1,0 +1,146 @@
+function Resolve-PlexFilter
+{
+    <#
+		.SYNOPSIS
+			Parses filter string into Plex API query.
+		.DESCRIPTION
+			Parses filter string into Plex API query. Filter syntax is '<Attribute> <Operator> <Value>'. Clauses are separated by semi-colons (;)
+		.EXAMPLE
+            Resolve-PlexFilter -MatchAll -Filter "Title BeginsWith Star Trek; Unplayed IsTrue"
+        .EXAMPLE
+            Resolve-PlexFilter -MatchAny -Filter "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
+        .EXAMPLE
+            Resolve-PlexFilter -MatchAll -Filter "Decade IsLessThan 1990s"
+	#>
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'MatchAny')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'MatchAll')]
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Filter,
+
+        [Parameter(ParameterSetName = "All")]
+        [switch]
+        $MatchAll,
+
+        [Parameter(ParameterSetName = "Any")]
+        [switch]
+        $MatchAny
+    )
+
+    # Copied from Plex web GUI.
+    # @{Class = @{Operator1, Operator2...}}
+    $Operators = @{
+        String   = @{
+            Contains       = "="
+            DoesNotContain = "!="
+            Is             = "=="
+            IsNot          = "!=="
+            BeginsWith     = "<="
+            EndsWith       = ">="
+        }
+        Numeric  = @{
+            Is            = "="
+            IsNot         = "!="
+            IsGreaterThan = ">>="
+            IsLessThan    = "<<="
+        }
+        Exact    = @{
+            Is    = "="
+            IsNot = "!="
+        }
+        Bool     = @{
+            IsTrue  = "=1"
+            IsFalse = "!=1"
+        }
+        SemiBool = @{
+            Is = "="
+        }
+        Date     = @{
+            IsBefore       = "<<="
+            IsAfter        = ">>="
+            IsInTheLast    = ">>=-"
+            IsNotInTheLast = "<<=-"
+        }
+    }
+
+    # Copied from Plex web GUI and translated into Plex DB attributes.
+    $Attributes = @{
+        Title            = @{ Class = "String" ; Name = "title" }
+        Studio           = @{ Class = "String" ; Name = "studio" }
+        Edition          = @{ Class = "String" ; Name = "editionTitle" }
+        Rating           = @{ Class = "Numeric" ; Name = "userRating" }
+        Year             = @{ Class = "Numeric" ; Name = "year" }
+        Decade           = @{ Class = "Numeric" ; Name = "decade" }
+        Plays            = @{ Class = "Numeric" ; Name = "viewCount" }
+        ContentRating    = @{ Class = "Exact" ; Name = "contentRating" }
+        Genre            = @{ Class = "Exact" ; Name = "genre" }
+        Collection       = @{ Class = "Exact" ; Name = "collection" }
+        Director         = @{ Class = "Exact" ; Name = "director" }
+        Writer           = @{ Class = "Exact" ; Name = "writer" }
+        Producer         = @{ Class = "Exact" ; Name = "producer" }
+        Actor            = @{ Class = "Exact" ; Name = "actor" }
+        Country          = @{ Class = "Exact" ; Name = "country" }
+        SubtitleLanguage = @{ Class = "Exact" ; Name = "subtitleLanguage" }
+        AudioLanguage    = @{ Class = "Exact" ; Name = "audioLanguage" }
+        Label            = @{ Class = "Exact" ; Name = "label" }
+        Unmatched        = @{ Class = "Bool" ; Name = "unmatched" }
+        Duplicate        = @{ Class = "Bool" ; Name = "duplicate" }
+        Unplayed         = @{ Class = "Bool" ; Name = "unwatched" }
+        HDR              = @{ Class = "Bool" ; Name = "hdr" }
+        InProgress       = @{ Class = "Bool" ; Name = "inProgress" }
+        Trash            = @{ Class = "Bool" ; Name = "trash" }
+        Resolution       = @{ Class = "SemiBool" ; Name = "resolution" }
+        ReleaseDate      = @{ Class = "Date" ; Name = "originallyAvailableAt" }
+        DateAdded        = @{ Class = "Date" ; Name = "addedAt" }
+        LastPlayed       = @{ Class = "Date" ; Name = "lastViewedAt" }
+    }
+
+    try
+    {
+        $Query = foreach ($Clause in ($Filter -split ';'))
+        {
+            # Parse out values from clause
+            if (-not ($Clause -match '(?<Attribute>\w+) (?<Operator>\w+)(?: (?<Value>.*))?'))
+            {
+                throw "Unable to parse filter clause '$Clause'. Syntax is '<Attribute> <Operator> <Value>'."
+            }
+
+            # Translate clause into API query and verify that it makes sense.
+            $Attribute = $Attributes[$Matches.Attribute]
+            $Operator = $Operators[$Attribute.Class].($Matches.Operator)
+            if (-not $Attribute)
+            {
+                throw "Unable to parse filter clause '$Clause'. Attribute does not exist in Plex DB."
+            }
+            if (-not $Operator)
+            {
+                throw "Unable to parse filter clause '$Clause'. Operator not supported by the attribute."
+            }
+
+            #TODO translate Exact class into Plex DB ratingKey
+
+            # Return API query
+            $Attribute.Name, $Operator, $Matches.Value -join ''
+        }
+
+        # Return entire API query
+        switch ($PSCmdlet.ParameterSetName)
+        {
+            "All" { $Query -join '&' ; continue }
+            "Any" { "push=1&{0}&pop=1" -f ($Query -join '&') ; continue }
+            default { throw "You should not see this." }
+        }
+    }
+    catch
+    {
+        if ($_.Exception.Message -match "Index operation failed")
+        {
+            throw "Unable to parse filter clause '$Clause'."
+        }
+        else { $PSCmdlet.ThrowTerminatingError($_) }
+    }
+}

--- a/Source/Private/Resolve-PlexFilter.ps1
+++ b/Source/Private/Resolve-PlexFilter.ps1
@@ -1,11 +1,11 @@
 function Resolve-PlexFilter
 {
     <#
-		.SYNOPSIS
-			Parses filter string into Plex API query.
-		.DESCRIPTION
-			Parses filter string into Plex API query. Filter syntax is '<Attribute> <Operator> <Value>'. Clauses are separated by semi-colons (;)
-		.EXAMPLE
+        .SYNOPSIS
+            Parses filter string into Plex API query.
+        .DESCRIPTION
+            Parses filter string into Plex API query. Filter syntax is '<Attribute> <Operator> <Value>'. Clauses are separated by semi-colons (;)
+        .EXAMPLE
             Resolve-PlexFilter -MatchAll -Filter "Title BeginsWith Star Trek; Unplayed IsTrue"
         .EXAMPLE
             Resolve-PlexFilter -MatchAny -Filter "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"

--- a/Source/Private/Resolve-PlexFilter.ps1
+++ b/Source/Private/Resolve-PlexFilter.ps1
@@ -10,137 +10,169 @@ function Resolve-PlexFilter
         .EXAMPLE
             Resolve-PlexFilter -MatchAny -Filter "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
         .EXAMPLE
-            Resolve-PlexFilter -MatchAll -Filter "Decade IsLessThan 1990s"
+            Resolve-PlexFilter -MatchAll -Filter "Actor IsNot Robert Pattinson; Title BeginsWith bat" -LibraryID 1
 	#>
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'MatchAny')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'MatchAll')]
-
     [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory)]
         [string]
         $Filter,
 
-        [Parameter(ParameterSetName = "All")]
-        [switch]
-        $MatchAll,
+        [Parameter()]
+        [ValidateSet("MatchAll", "MatchAny")]
+        [string]
+        $MatchType = "MatchAll",
 
-        [Parameter(ParameterSetName = "Any")]
+        [Parameter()]
+        [string]
+        $LibraryID,
+
+        [Parameter(DontShow)]
         [switch]
-        $MatchAny
+        $IKnowWhatImDoing
     )
 
-    # Copied from Plex web GUI.
-    # @{Class = @{Operator1, Operator2...}}
-    $Operators = @{
-        String   = @{
-            Contains       = "="
-            DoesNotContain = "!="
-            Is             = "=="
-            IsNot          = "!=="
-            BeginsWith     = "<="
-            EndsWith       = ">="
-        }
-        Numeric  = @{
-            Is            = "="
-            IsNot         = "!="
-            IsGreaterThan = ">>="
-            IsLessThan    = "<<="
-        }
-        Exact    = @{
-            Is    = "="
-            IsNot = "!="
-        }
-        Bool     = @{
-            IsTrue  = "=1"
-            IsFalse = "!=1"
-        }
-        SemiBool = @{
-            Is = "="
-        }
-        Date     = @{
-            IsBefore       = "<<="
-            IsAfter        = ">>="
-            IsInTheLast    = ">>=-"
-            IsNotInTheLast = "<<=-"
-        }
-    }
-
-    # Copied from Plex web GUI and translated into Plex DB attributes.
-    $Attributes = @{
-        Title            = @{ Class = "String" ; Name = "title" }
-        Studio           = @{ Class = "String" ; Name = "studio" }
-        Edition          = @{ Class = "String" ; Name = "editionTitle" }
-        Rating           = @{ Class = "Numeric" ; Name = "userRating" }
-        Year             = @{ Class = "Numeric" ; Name = "year" }
-        Decade           = @{ Class = "Numeric" ; Name = "decade" }
-        Plays            = @{ Class = "Numeric" ; Name = "viewCount" }
-        ContentRating    = @{ Class = "Exact" ; Name = "contentRating" }
-        Genre            = @{ Class = "Exact" ; Name = "genre" }
-        Collection       = @{ Class = "Exact" ; Name = "collection" }
-        Director         = @{ Class = "Exact" ; Name = "director" }
-        Writer           = @{ Class = "Exact" ; Name = "writer" }
-        Producer         = @{ Class = "Exact" ; Name = "producer" }
-        Actor            = @{ Class = "Exact" ; Name = "actor" }
-        Country          = @{ Class = "Exact" ; Name = "country" }
-        SubtitleLanguage = @{ Class = "Exact" ; Name = "subtitleLanguage" }
-        AudioLanguage    = @{ Class = "Exact" ; Name = "audioLanguage" }
-        Label            = @{ Class = "Exact" ; Name = "label" }
-        Unmatched        = @{ Class = "Bool" ; Name = "unmatched" }
-        Duplicate        = @{ Class = "Bool" ; Name = "duplicate" }
-        Unplayed         = @{ Class = "Bool" ; Name = "unwatched" }
-        HDR              = @{ Class = "Bool" ; Name = "hdr" }
-        InProgress       = @{ Class = "Bool" ; Name = "inProgress" }
-        Trash            = @{ Class = "Bool" ; Name = "trash" }
-        Resolution       = @{ Class = "SemiBool" ; Name = "resolution" }
-        ReleaseDate      = @{ Class = "Date" ; Name = "originallyAvailableAt" }
-        DateAdded        = @{ Class = "Date" ; Name = "addedAt" }
-        LastPlayed       = @{ Class = "Date" ; Name = "lastViewedAt" }
-    }
-
-    try
+    end
     {
-        $Query = foreach ($Clause in ($Filter -split ';'))
-        {
-            # Parse out values from clause
-            if (-not ($Clause -match '(?<Attribute>\w+) (?<Operator>\w+)(?: (?<Value>.*))?'))
-            {
-                throw "Unable to parse filter clause '$Clause'. Syntax is '<Attribute> <Operator> <Value>'."
+        # Copied from Plex web GUI.
+        $Operators = @{
+            # Class    = @{
+            #     Operator1 = "..."
+            #     Operator2 = "..."
+            # }
+            String   = @{
+                Contains       = "="
+                DoesNotContain = "!="
+                Is             = "=="
+                IsNot          = "!=="
+                BeginsWith     = "<="
+                EndsWith       = ">="
             }
-
-            # Translate clause into API query and verify that it makes sense.
-            $Attribute = $Attributes[$Matches.Attribute]
-            $Operator = $Operators[$Attribute.Class].($Matches.Operator)
-            if (-not $Attribute)
-            {
-                throw "Unable to parse filter clause '$Clause'. Attribute does not exist in Plex DB."
+            Numeric  = @{
+                Is            = "="
+                IsNot         = "!="
+                IsGreaterThan = ">>="
+                IsLessThan    = "<<="
             }
-            if (-not $Operator)
-            {
-                throw "Unable to parse filter clause '$Clause'. Operator not supported by the attribute."
+            Exact    = @{
+                Is    = "="
+                IsNot = "!="
             }
-
-            #TODO translate Exact class into Plex DB ratingKey
-
-            # Return API query
-            $Attribute.Name, $Operator, $Matches.Value -join ''
+            Bool     = @{
+                IsTrue  = "=1"
+                IsFalse = "!=1"
+            }
+            SemiBool = @{
+                Is = "="
+            }
+            Date     = @{
+                IsBefore       = "<<="
+                IsAfter        = ">>="
+                IsInTheLast    = ">>=-"
+                IsNotInTheLast = "<<=-"
+            }
         }
 
-        # Return entire API query
-        switch ($PSCmdlet.ParameterSetName)
-        {
-            "All" { $Query -join '&' ; continue }
-            "Any" { "push=1&{0}&pop=1" -f ($Query -join '&') ; continue }
-            default { throw "You should not see this." }
+        # Copied from Plex web GUI and translated into Plex DB attributes.
+        $Attributes = @{
+            # NameinGUI        = @{ Class = "ClassName" ; Name = "NameInDB" }
+            Title            = @{ Class = "String" ; Name = "title" }
+            Studio           = @{ Class = "String" ; Name = "studio" }
+            Edition          = @{ Class = "String" ; Name = "editionTitle" }
+            Rating           = @{ Class = "Numeric" ; Name = "userRating" }
+            Year             = @{ Class = "Numeric" ; Name = "year" }
+            Decade           = @{ Class = "Numeric" ; Name = "decade" }
+            Plays            = @{ Class = "Numeric" ; Name = "viewCount" }
+            ContentRating    = @{ Class = "Exact" ; Name = "contentRating" }
+            Genre            = @{ Class = "Exact" ; Name = "genre" }
+            Collection       = @{ Class = "Exact" ; Name = "collection" }
+            Director         = @{ Class = "Exact" ; Name = "director" }
+            Writer           = @{ Class = "Exact" ; Name = "writer" }
+            Producer         = @{ Class = "Exact" ; Name = "producer" }
+            Actor            = @{ Class = "Exact" ; Name = "actor" }
+            Country          = @{ Class = "Exact" ; Name = "country" }
+            SubtitleLanguage = @{ Class = "Exact" ; Name = "subtitleLanguage" }
+            AudioLanguage    = @{ Class = "Exact" ; Name = "audioLanguage" }
+            Label            = @{ Class = "Exact" ; Name = "label" }
+            Unmatched        = @{ Class = "Bool" ; Name = "unmatched" }
+            Duplicate        = @{ Class = "Bool" ; Name = "duplicate" }
+            Unplayed         = @{ Class = "Bool" ; Name = "unwatched" }
+            HDR              = @{ Class = "Bool" ; Name = "hdr" }
+            InProgress       = @{ Class = "Bool" ; Name = "inProgress" }
+            Trash            = @{ Class = "Bool" ; Name = "trash" }
+            Resolution       = @{ Class = "SemiBool" ; Name = "resolution" }
+            ReleaseDate      = @{ Class = "Date" ; Name = "originallyAvailableAt" }
+            DateAdded        = @{ Class = "Date" ; Name = "addedAt" }
+            LastPlayed       = @{ Class = "Date" ; Name = "lastViewedAt" }
         }
-    }
-    catch
-    {
-        if ($_.Exception.Message -match "Index operation failed")
+
+        try
         {
-            throw "Unable to parse filter clause '$Clause'."
+            $Query = foreach ($Clause in ($Filter -split ';'))
+            {
+                # Parse out values from clause
+                if (-not ($Clause -match '(?<Attribute>\w+) (?<Operator>\w+)(?: (?<Value>.*))?'))
+                {
+                    throw "Unable to parse filter clause '$Clause'. Syntax is '<Attribute> <Operator> <Value>'."
+                }
+
+                # Translate clause into API query and verify that it makes sense.
+                $Attribute = $Attributes[$Matches.Attribute]
+                $Operator = $Operators[$Attribute.Class].($Matches.Operator)
+                if (-not $Attribute)
+                {
+                    throw "Unable to parse filter clause '$Clause'. Attribute does not exist in Plex DB."
+                }
+                if (-not $Operator)
+                {
+                    throw "Unable to parse filter clause '$Clause'. Operator not supported by the attribute."
+                }
+
+                # Translate Exact class into Plex DB key
+                if ($Attribute.Class -eq 'Exact')
+                {
+                    if (!$script:PlexConfigData)
+                    {
+                        try
+                        {
+                            Import-PlexConfiguration -WhatIf:$False
+                        }
+                        catch
+                        {
+                            throw $_
+                        }
+                    }
+                    $Uri = Get-PlexAPIUri -RestEndpoint "library/sections/$($PSBoundParameters.LibraryID)/$($Attribute.Name)" -ErrorAction Stop
+                    $Key = ((Invoke-RestMethod -Uri $Uri -Method Get -ErrorAction Stop).MediaContainer.Directory | Where-Object { $_.title -eq $Matches.Value }).key
+                    if (-not ($Key -or $IKnowWhatImDoing))
+                    {
+                        throw ("Unable to find key for '{0}' in library '{1}'." -f $Matches.Value, $PSBoundParameters.LibraryID)
+                    }
+
+                    $Matches.Value = @($Matches.Value, $Key)[[bool]$Key] # Null check for key
+                }
+
+                # Return API query
+                $Attribute.Name, $Operator, $Matches.Value -join ''
+            }
+
+            # Return entire API query
+            switch ($MatchType)
+            {
+                "MatchAll" { $Query -join '&' ; continue }
+                "MatchAny" { "push=1&{0}&pop=1" -f ($Query -join '&or=1&') ; continue }
+                default { throw "You should not see this." }
+            }
         }
-        else { $PSCmdlet.ThrowTerminatingError($_) }
+        catch
+        {
+            if ($_.Exception.Message -match "Index operation failed")
+            {
+                throw "Unable to parse filter clause '$Clause'."
+            }
+            else { $PSCmdlet.ThrowTerminatingError($_) }
+        }
     }
 }

--- a/Source/Public/New-PlexSmartCollection.ps1
+++ b/Source/Public/New-PlexSmartCollection.ps1
@@ -10,7 +10,7 @@
         .PARAMETER LibraryID
             ID of the library to create the smart collection in.
         .PARAMETER Filter
-            Specifies the query string that retrieves the items in the smart collection. The syntax matches the Plex Web GUI as closely as possible. Clauses are separated by a semi-colon (;)
+            Specifies the query string that retrieves the items in the smart collection. The syntax matches the Plex Web GUI as closely as possible. Clauses are separated by a semi-colon ( ; ).
 
             Syntax:
 
@@ -82,11 +82,15 @@
                 - "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
                 - "Title BeginsWith Star Trek; Unplayed IsTrue"
                 - "Actor Is Jim Carrey; Genre Is Comedy"
+        .PARAMETER MatchType
+            Specifies how filter clauses are matched.
 
+            - MatchAll: Matches all clauses.
+            - MatchAny: Matches any cluase.
         .EXAMPLE
             New-PlexSmartCollection -Name "Star Trek" -LibraryID 1 -Filter "Title Contains Star Trek"
         .EXAMPLE
-            New-PlexSmartCollection -Name "80's" -LibraryID 1 -Filter "Decade Is 1980s"
+            New-PlexSmartCollection -Name "80's" -LibraryID 1 -Filter "Decade Is 1980"
         .EXAMPLE
             New-PlexSmartCollection -Name "Old Favorites" -LibraryID 1 -Filter "Plays IsGreaterThan 2; LastPlayed IsNotInTheLast 1y"
         .EXAMPLE
@@ -137,7 +141,7 @@
         }
     }
     catch {
-        $PSCmdlet.ThrowTerminatingErrorError($_)
+        $PSCmdlet.ThrowTerminatingError($_)
     }
     #EndRegion
 

--- a/Source/Public/New-PlexSmartCollection.ps1
+++ b/Source/Public/New-PlexSmartCollection.ps1
@@ -1,0 +1,193 @@
+function New-PlexSmartCollection
+{
+    <#
+        .SYNOPSIS
+            Creates a new smart collection.
+        .DESCRIPTION
+            Creates a new smart collection.
+        .PARAMETER Name
+            Name of the smart collection.
+        .PARAMETER LibraryID
+            ID of the library to create the smart collection in.
+        .PARAMETER Filter
+            Specifies the query string that retrieves the items in the smart collection. The syntax matches the Plex Web GUI as closely as possible. Clauses are separated by a semi-colon (;)
+
+            Syntax:
+
+            <Atttribute> <Operator> <Value>
+            <Atttribute> <Operator> <Value>;<Atttribute> <Operator> <Value>
+
+            Attributes:
+                - String
+                    - Title
+                    - Studio
+                    - Edition
+                - Numeric
+                    - Rating
+                    - Year
+                    - Decade
+                    - Plays
+                - Exact
+                    - ContentRating
+                    - Genre
+                    - Collection
+                    - Actor
+                    - Country
+                    - SubtitleLanguage
+                    - AudioLanguage
+                    - Label
+                - Boolean
+                    - Unmatched
+                    - Duplicate
+                    - Unplayed
+                    - HDR
+                    - InProgress
+                    - Trash
+                - Semi-Boolean
+                    - Resolution
+                - Date
+                    - ReleaseDate
+                    - DateAdded
+                    - LastPlayed
+
+            Operators:
+                - String
+                    - Contains
+                    - DoesNotContain
+                    - Is
+                    - IsNot
+                    - BeginsWith
+                    - EndsWith
+                - Numeric
+                    - Is
+                    - IsNot
+                    - IsGreaterThan
+                    - IsLessThan
+                - Exact
+                    - Is
+                    - IsNot
+                - Boolean
+                    - IsTrue
+                    - IsFalse
+                - Semi-Boolean
+                    - Is
+                - Date
+                    - IsBefore (Value format: yyyy-mm-dd)
+                    - IsAfter (Value format: yyyy-mm-dd)
+                    - IsInTheLast
+                    - IsNotInTheLast
+
+            Examples:
+
+                - "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
+                - "Title BeginsWith Star Trek; Unplayed IsTrue"
+                - "Actor Is Jim Carrey; Genre Is Comedy"
+
+        .EXAMPLE
+            New-PlexSmartCollection -Name "Star Trek" -LibraryID 1 -Filter "Title Contains Star Trek"
+        .EXAMPLE
+            New-PlexSmartCollection -Name "80's" -LibraryID 1 -Filter "Decade Is 1980s"
+        .EXAMPLE
+            New-PlexSmartCollection -Name "Old Favorites" -LibraryID 1 -Filter "Plays IsGreaterThan 2; LastPlayed IsNotInTheLast 1y"
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory)]
+        [string]
+        $LibraryID,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Filter,
+
+        [Parameter()]
+        [ValidateSet("MatchAll", "MatchAny")]
+        [string]
+        $MatchType = "MatchAll"
+    )
+
+    #############################################################################
+	#Region Import Plex Configuration
+	if(!$script:PlexConfigData)
+	{
+		try
+		{
+			Import-PlexConfiguration -WhatIf:$False
+		}
+		catch
+		{
+			throw $_
+		}
+	}
+	#EndRegion
+
+    #############################################################################
+	#Region Check if collection already exists
+    try {
+        $Collections = Get-PlexCollection -LibraryId $LibraryID
+        if ($Collections.title -contains $Name){
+            throw "Collection '$Name' already exits"
+        }
+    }
+    catch {
+        $PSCmdlet.ThrowTerminatingErrorError($_)
+    }
+    #EndRegion
+
+    #############################################################################
+	#Region Get machine identifier
+	Write-Verbose -Message "Function: $($MyInvocation.MyCommand): Getting list of Plex servers (to get machine identifier)"
+	try
+	{
+		$CurrentPlexServer = Get-PlexServer -Name $DefaultPlexServer.PlexServer -ErrorAction Stop
+		if(!$CurrentPlexServer)
+		{
+			throw "Could not find $CurrentPlexServer in $($Servers -join ', ')"
+		}
+	}
+	catch
+	{
+		throw $_
+	}
+	#EndRegion
+
+    #############################################################################
+	#Region Construct Uri
+    try {
+        $Items = Resolve-PlexFilter -MatchType $MatchType -LibraryID $LibraryID -Filter $Filter
+        $Params = @{
+            title = $Name
+            smart = '1'
+            sectionID = $LibraryID
+            uri = "server://$($CurrentPlexServer.machineIdentifier)/com.plexapp.plugins.library/library/sections/$LibraryID/$Items"
+        }
+
+        $DataUri = Get-PlexAPIUrl -RestEndpoint "library/sections/$LibraryID" -Params $Params
+    }
+    catch {
+        $PSCmdlet.ThrowTerminatingError($_)
+    }
+    #EndRegion
+    
+    #############################################################################
+	#Region Make request
+	if($PSCmdlet.ShouldProcess($Name, "Create Smart Collection '$Name'"))
+	{
+		Write-Verbose -Message "Function: $($MyInvocation.MyCommand): Creating Smart Collection $Name in Libary '$LibraryID'"
+		try
+		{
+			$Data = Invoke-RestMethod -Uri $DataUri -Method POST
+			return $Data.mediacontainer.metadata
+		}
+		catch
+		{
+			throw $_
+		}
+	}
+	#EndRegion
+}

--- a/Source/Public/New-PlexSmartCollection.ps1
+++ b/Source/Public/New-PlexSmartCollection.ps1
@@ -14,10 +14,10 @@
 
             Syntax:
 
-            <Atttribute> <Operator> <Value>
-            <Atttribute> <Operator> <Value>;<Atttribute> <Operator> <Value>
+            - <Atttribute> <Operator> <Value>
+            - <Atttribute> <Operator> <Value>;<Atttribute> <Operator> <Value>
 
-            Attributes:
+            - Attributes:
                 - String
                     - Title
                     - Studio
@@ -50,7 +50,7 @@
                     - DateAdded
                     - LastPlayed
 
-            Operators:
+                - Operators:
                 - String
                     - Contains
                     - DoesNotContain
@@ -77,11 +77,11 @@
                     - IsInTheLast
                     - IsNotInTheLast
 
-            Examples:
-
+            - Examples:
                 - "DateAdded IsNotInTheLast 2y; Unplayed IsTrue"
                 - "Title BeginsWith Star Trek; Unplayed IsTrue"
                 - "Actor Is Jim Carrey; Genre Is Comedy"
+
         .PARAMETER MatchType
             Specifies how filter clauses are matched.
 


### PR DESCRIPTION
The new cmdlet creates smart collections using the filter syntax from the web GUI.  Tried my best to match the syntax, but it may require a sanity check to see if it makes sense.

The new private cmdlet Resolve-Plex filter can also be used to add a "-filter" parameter to other cmdlets, like Get-PlexItem, in the future.

Thanks in advance!