### PR TITLE
Correct version for release 1.0.19

### DIFF
--- a/Source/PSPlex.psd1
+++ b/Source/PSPlex.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSPlex.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.0.18'
+    ModuleVersion        = '1.0.19'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Core', 'Desktop'
@@ -149,4 +149,3 @@
     # DefaultCommandPrefix = ''
 
 }
-


### PR DESCRIPTION
Fixes #23 (or should) - increments the version to 1.0.19 to match what the CHANGELOG says should have been released.